### PR TITLE
feat: add stock watchlist MVP

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,14 +1,184 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.app-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+
+.top-bar h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.controls input[type="text"],
+.controls input[type="date"] {
+  padding: 4px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+
+.table-wrapper {
+  overflow: auto;
+  flex: 1;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+tbody td {
+  padding: 8px;
+  border-bottom: 1px solid #f3f4f6;
+  vertical-align: top;
+}
+
+tbody tr:nth-child(even) {
+  background: #f9fafb;
+}
+
+tbody tr:hover {
+  background: #f1f5f9;
+}
+
+.symbol {
+  font-weight: bold;
+}
+
+.name {
+  color: var(--color-secondary-text);
+  font-size: 0.875rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.badge.status-undervalued {
+  background: var(--color-success);
+  color: #fff;
+}
+
+.badge.status-overvalued {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+.badge.status-fair {
+  background: var(--color-neutral);
+  color: #fff;
+}
+
+.badge.status-incomplete {
+  background: #e5e7eb;
+  color: var(--color-primary-text);
+}
+
+.badge.soon {
+  background: var(--color-soon-bg);
+  color: var(--color-soon-text);
+}
+
+.empty-state {
+  padding: 32px;
   text-align: center;
+  color: var(--color-secondary-text);
 }
 
-.card {
-  padding: 2em;
+.edited {
+  font-style: italic;
 }
 
-.read-the-docs {
-  color: #888;
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 320px;
+  max-width: 100%;
+  height: 100%;
+  background: #fff;
+  box-shadow: -2px 0 8px rgba(0,0,0,0.1);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  padding: 16px;
+  overflow-y: auto;
+  z-index: 30;
+}
+
+.drawer.open {
+  transform: translateX(0);
+}
+
+.drawer h2 {
+  margin-top: 0;
+}
+
+.drawer label {
+  display: block;
+  margin-top: 12px;
+  font-size: 0.875rem;
+}
+
+.drawer input,
+.drawer textarea {
+  width: 100%;
+  padding: 4px 8px;
+  margin-top: 4px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+
+.drawer .actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.drawer button {
+  padding: 6px 12px;
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  border-radius: 4px;
+}
+
+.upside-positive {
+  color: var(--color-success);
+}
+
+.upside-negative {
+  color: var(--color-danger);
+}
+
+.upside-neutral {
+  color: var(--color-neutral);
 }

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,27 +1,140 @@
-import { useState } from 'react'
-import './App.css'
+import { useState } from 'react';
+import './App.css';
+import TableRow from './components/TableRow';
+import EditDrawer from './components/EditDrawer';
+import type { Ticker } from './types';
+
+const emptyTicker: Ticker = {
+  symbol: '',
+  name: '',
+  fairValue: undefined,
+  fairAsOf: '',
+  priceClose: undefined,
+  priceAsOf: '',
+  earningsDate: '',
+  notes: '',
+  edited: false,
+};
+
+const initialData: Ticker[] = [
+  {
+    symbol: 'MCD',
+    name: 'McDonald\u2019s Corporation',
+    fairValue: 150,
+    fairAsOf: '2025-07-01',
+    priceClose: 120,
+    priceAsOf: '2025-08-10',
+    earningsDate: '2025-10-25',
+    notes: '',
+    edited: false,
+  },
+  {
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    fairValue: 180,
+    fairAsOf: '2025-07-02',
+    priceClose: 195,
+    priceAsOf: '2025-08-10',
+    earningsDate: '2025-10-30',
+    notes: '',
+    edited: false,
+  },
+];
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [tickers, setTickers] = useState<Ticker[]>(initialData);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [filterDate, setFilterDate] = useState('');
+  const [search, setSearch] = useState('');
+
+  const openEdit = (idx: number) => {
+    setEditingIndex(idx);
+    setDrawerOpen(true);
+  };
+
+  const addTicker = () => {
+    setEditingIndex(null);
+    setDrawerOpen(true);
+  };
+
+  const saveTicker = (t: Ticker) => {
+    const list = [...tickers];
+    if (editingIndex === null) {
+      list.push({ ...t, edited: true });
+    } else {
+      list[editingIndex] = { ...t, edited: true };
+    }
+    setTickers(list);
+    setDrawerOpen(false);
+  };
+
+  const cancelEdit = () => setDrawerOpen(false);
+
+  const filtered = tickers.filter((t) => {
+    const term = search.toLowerCase();
+    const matchesSearch =
+      t.symbol.toLowerCase().includes(term) || t.name.toLowerCase().includes(term);
+    const matchesDate = filterDate ? t.priceAsOf === filterDate : true;
+    return matchesSearch && matchesDate;
+  });
 
   return (
-    <>
-      <div>
-        <h1>DCF Valuation Stock</h1>
+    <div className="app-container">
+      <div className="top-bar">
+        <h1>Stock Watchlist</h1>
+        <div className="controls">
+          <button onClick={addTicker}>Add Ticker</button>
+          <button onClick={() => alert('Export as CSV')}>Export CSV</button>
+          <input
+            type="date"
+            value={filterDate}
+            onChange={(e) => setFilterDate(e.target.value)}
+            aria-label="Price As-Of"
+          />
+          <input
+            type="text"
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
       </div>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Welcome to DCF Valuation Stock Calculator
-      </p>
-    </>
-  )
+      {filtered.length === 0 ? (
+        <p className="empty-state">No tickers yet. Click Add Ticker to begin.</p>
+      ) : (
+        <div className="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Symbol</th>
+                <th>Fair Value</th>
+                <th>Fair As-Of</th>
+                <th>Price Close</th>
+                <th>Price As-Of</th>
+                <th>Upcoming Earnings</th>
+                <th>Upside %</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((t, idx) => (
+                <TableRow key={idx} ticker={t} onClick={() => openEdit(idx)} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {drawerOpen && (
+        <EditDrawer
+          initial={editingIndex === null ? emptyTicker : tickers[editingIndex]}
+          open={drawerOpen}
+          onSave={saveTicker}
+          onCancel={cancelEdit}
+        />
+      )}
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/my-app/src/components/Badge.tsx
+++ b/my-app/src/components/Badge.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import type { Status } from '../types';
+
+interface BadgeProps {
+  text: string;
+  type: Status | 'SOON';
+}
+
+const Badge: React.FC<BadgeProps> = ({ text, type }) => {
+  const className = type === 'SOON' ? 'badge soon' : `badge status-${type.toLowerCase()}`;
+  return <span className={className}>{text}</span>;
+};
+
+export default Badge;

--- a/my-app/src/components/EditDrawer.tsx
+++ b/my-app/src/components/EditDrawer.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import type { Ticker } from '../types';
+
+interface Props {
+  initial: Ticker;
+  open: boolean;
+  onSave: (t: Ticker) => void;
+  onCancel: () => void;
+}
+
+const EditDrawer: React.FC<Props> = ({ initial, open, onSave, onCancel }) => {
+  const [form, setForm] = useState<Ticker>(initial);
+
+  useEffect(() => {
+    setForm(initial);
+  }, [initial]);
+
+  const update = (field: keyof Ticker, value: string) => {
+    setForm({ ...form, [field]: value });
+  };
+
+  const updateNumber = (field: keyof Ticker, value: string) => {
+    const num = value === '' ? undefined : Number(value);
+    setForm({ ...form, [field]: num });
+  };
+
+  return (
+    <div className={`drawer ${open ? 'open' : ''}`}>
+      <h2>{initial.symbol ? 'Edit Ticker' : 'Add Ticker'}</h2>
+      <label>
+        Symbol
+        <input
+          value={form.symbol || ''}
+          onChange={(e) => update('symbol', e.target.value)}
+        />
+      </label>
+      <label>
+        Name
+        <input value={form.name || ''} onChange={(e) => update('name', e.target.value)} />
+      </label>
+      <label>
+        Fair Value
+        <input
+          type="number"
+          value={form.fairValue ?? ''}
+          onChange={(e) => updateNumber('fairValue', e.target.value)}
+        />
+      </label>
+      <label>
+        Fair As-Of
+        <input
+          type="date"
+          value={form.fairAsOf || ''}
+          onChange={(e) => update('fairAsOf', e.target.value)}
+        />
+      </label>
+      <label>
+        Price Close
+        <input
+          type="number"
+          value={form.priceClose ?? ''}
+          onChange={(e) => updateNumber('priceClose', e.target.value)}
+        />
+      </label>
+      <label>
+        Price As-Of
+        <input
+          type="date"
+          value={form.priceAsOf || ''}
+          onChange={(e) => update('priceAsOf', e.target.value)}
+        />
+      </label>
+      <label>
+        Upcoming Earnings
+        <input
+          type="date"
+          value={form.earningsDate || ''}
+          onChange={(e) => update('earningsDate', e.target.value)}
+        />
+      </label>
+      <label>
+        Notes
+        <textarea
+          rows={3}
+          value={form.notes || ''}
+          onChange={(e) => update('notes', e.target.value)}
+        />
+      </label>
+      <div className="actions">
+        <button onClick={() => onSave(form)}>Save</button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+};
+
+export default EditDrawer;

--- a/my-app/src/components/TableRow.tsx
+++ b/my-app/src/components/TableRow.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Badge from './Badge';
+import type { Ticker, Status } from '../types';
+
+interface RowProps {
+  ticker: Ticker;
+  onClick: () => void;
+}
+
+const currency = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+const calcUpside = (t: Ticker): number | null => {
+  if (t.fairValue == null || t.priceClose == null || t.priceClose === 0) return null;
+  return ((t.fairValue - t.priceClose) / t.priceClose) * 100;
+};
+
+const statusFromUpside = (t: Ticker, up: number | null): Status => {
+  if (t.fairValue == null || t.priceClose == null) return 'INCOMPLETE';
+  if (up != null) {
+    if (up >= 20) return 'UNDERVALUED';
+    if (up <= -10) return 'OVERVALUED';
+    return 'FAIR';
+  }
+  return 'INCOMPLETE';
+};
+
+const isSoon = (date?: string): boolean => {
+  if (!date) return false;
+  const now = new Date();
+  const d = new Date(date);
+  const diff = (d.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+  return diff >= 0 && diff <= 21;
+};
+
+const TableRow: React.FC<RowProps> = ({ ticker, onClick }) => {
+  const upside = calcUpside(ticker);
+  const status = statusFromUpside(ticker, upside);
+  const soon = isSoon(ticker.earningsDate);
+  const upsideText =
+    upside == null ? '' : `${upside >= 0 ? '+' : ''}${upside.toFixed(1)}%`;
+  let upsideClass = 'upside-neutral';
+  if (upside != null) {
+    if (upside >= 20) upsideClass = 'upside-positive';
+    else if (upside <= -10) upsideClass = 'upside-negative';
+  }
+
+  return (
+    <tr className={ticker.edited ? 'edited' : ''} onClick={onClick}>
+      <td>
+        <div className="symbol">{ticker.symbol}</div>
+        <div className="name">{ticker.name}</div>
+      </td>
+      <td>{ticker.fairValue != null ? currency.format(ticker.fairValue) : ''}</td>
+      <td>{ticker.fairAsOf}</td>
+      <td>{ticker.priceClose != null ? currency.format(ticker.priceClose) : ''}</td>
+      <td>{ticker.priceAsOf}</td>
+      <td>
+        {ticker.earningsDate}
+        {soon && <Badge text="Soon" type="SOON" />}
+      </td>
+      <td className={upsideClass} title="(Fair − Price) / Price">{upsideText}</td>
+      <td>
+        <Badge text={status} type={status} />
+      </td>
+    </tr>
+  );
+};
+
+export default TableRow;

--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -1,68 +1,22 @@
 :root {
+  --color-primary-text: #111;
+  --color-secondary-text: #6B7280;
+  --color-success: #16A34A;
+  --color-danger: #DC2626;
+  --color-neutral: #6B7280;
+  --color-soon-bg: #FFF7ED;
+  --color-soon-text: #C2410C;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  color: var(--color-primary-text);
+  background: #ffffff;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/my-app/src/types.ts
+++ b/my-app/src/types.ts
@@ -1,0 +1,13 @@
+export interface Ticker {
+  symbol: string;
+  name: string;
+  fairValue?: number;
+  fairAsOf?: string;
+  priceClose?: number;
+  priceAsOf?: string;
+  earningsDate?: string;
+  notes?: string;
+  edited?: boolean;
+}
+
+export type Status = 'UNDERVALUED' | 'OVERVALUED' | 'FAIR' | 'INCOMPLETE';


### PR DESCRIPTION
## Summary
- implement single-page stock watchlist with sample data
- add editable drawer and status badges for fair value comparisons
- style table with sticky header, zebra rows, and color tokens

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689922b36b4083329fd2ba9ab5b9e054