### PR TITLE
feat: add design tokens and Inter font

### DIFF
--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -32,7 +33,26 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 47.4% 11.2%;
 
-    --radius: 0.5rem;
+    --radius: 1rem;
+
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 1rem;
+    --space-4: 1.5rem;
+    --space-5: 2rem;
+
+    --shadow-sm: 0 1px 2px 0 hsl(0 0% 0% / 0.05);
+    --shadow-md: 0 4px 6px -1px hsl(0 0% 0% / 0.1), 0 2px 4px -2px hsl(0 0% 0% / 0.1);
+    --shadow-lg: 0 10px 15px -3px hsl(0 0% 0% / 0.1), 0 4px 6px -4px hsl(0 0% 0% / 0.1);
+
+    --success: 142 71.8% 29.2%;
+    --success-foreground: 0 0% 100%;
+    --warning: 26 90.5% 37.1%;
+    --warning-foreground: 0 0% 100%;
+    --error: 0 72.2% 50.6%;
+    --error-foreground: 0 0% 100%;
+    --neutral: 215 13.8% 34.1%;
+    --neutral-foreground: 0 0% 100%;
 
     /* legacy color tokens */
     --color-secondary-text: #6B7280;
@@ -78,6 +98,14 @@
     --color-neutral: #6B7280;
     --color-soon-bg: #9A3412;
     --color-soon-text: #FFEDD5;
+    --success: 142 71.8% 29.2%;
+    --success-foreground: 0 0% 100%;
+    --warning: 26 90.5% 37.1%;
+    --warning-foreground: 0 0% 100%;
+    --error: 0 72.2% 50.6%;
+    --error-foreground: 0 0% 100%;
+    --neutral: 215 13.8% 34.1%;
+    --neutral-foreground: 0 0% 100%;
   }
 
   * {
@@ -86,5 +114,6 @@
 
   body {
     @apply bg-background text-foreground;
+    font-family: 'Inter', sans-serif;
   }
 }

--- a/my-app/src/tokens.ts
+++ b/my-app/src/tokens.ts
@@ -1,0 +1,37 @@
+export const spacing = {
+  1: '0.25rem',
+  2: '0.5rem',
+  3: '1rem',
+  4: '1.5rem',
+  5: '2rem',
+};
+
+export const radii = {
+  DEFAULT: '1rem', // 2xl
+};
+
+export const shadows = {
+  sm: '0 1px 2px 0 rgba(0,0,0,0.05)',
+  md: '0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1)',
+  lg: '0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1)',
+};
+
+export const semanticColors = {
+  success: '#15803d',
+  'success-foreground': '#ffffff',
+  warn: '#b45309',
+  'warn-foreground': '#ffffff',
+  error: '#dc2626',
+  'error-foreground': '#ffffff',
+  neutral: '#4b5563',
+  'neutral-foreground': '#ffffff',
+};
+
+export const tokens = {
+  spacing,
+  radii,
+  shadows,
+  colors: semanticColors,
+};
+
+export default tokens;

--- a/my-app/tailwind.config.js
+++ b/my-app/tailwind.config.js
@@ -38,11 +38,42 @@ module.exports = {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        success: {
+          DEFAULT: 'hsl(var(--success))',
+          foreground: 'hsl(var(--success-foreground))',
+        },
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          foreground: 'hsl(var(--warning-foreground))',
+        },
+        error: {
+          DEFAULT: 'hsl(var(--error))',
+          foreground: 'hsl(var(--error-foreground))',
+        },
+        neutral: {
+          DEFAULT: 'hsl(var(--neutral))',
+          foreground: 'hsl(var(--neutral-foreground))',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
+      },
+      boxShadow: {
+        sm: 'var(--shadow-sm)',
+        md: 'var(--shadow-md)',
+        lg: 'var(--shadow-lg)',
+      },
+      spacing: {
+        1: 'var(--space-1)',
+        2: 'var(--space-2)',
+        3: 'var(--space-3)',
+        4: 'var(--space-4)',
+        5: 'var(--space-5)',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Summary
- define spacing, radii, shadow, and semantic color tokens
- map tokens to Tailwind via CSS variables and import Inter font

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7c21593083328d8264e5eb1bf1bd