### PR TITLE
feat: add shadcn toolbar app shell

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -5,37 +5,6 @@
   background: hsl(var(--background));
   color: hsl(var(--foreground));
 }
-
-.top-bar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px;
-  border-bottom: 1px solid #e5e7eb;
-  background: hsl(var(--background));
-  position: sticky;
-  top: 0;
-  z-index: 20;
-}
-
-.top-bar h1 {
-  margin: 0;
-  font-size: 1.5rem;
-}
-
-.controls {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.controls input[type="text"],
-.controls input[type="date"] {
-  padding: 4px 8px;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-}
-
 .table-wrapper {
   overflow: auto;
   flex: 1;

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,9 +1,16 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { format } from 'date-fns';
 import './App.css';
 import TableRow from './components/TableRow';
 import EditDrawer from './components/EditDrawer';
 import type { Ticker } from './types';
 import { ModeToggle } from '@/components/mode-toggle';
+import AppShell from '@/components/AppShell';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
+import { useTheme } from '@/components/theme-provider';
 
 const emptyTicker: Ticker = {
   symbol: '',
@@ -46,8 +53,10 @@ function App() {
   const [tickers, setTickers] = useState<Ticker[]>(initialData);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [filterDate, setFilterDate] = useState('');
+  const [filterDate, setFilterDate] = useState<Date | undefined>();
   const [search, setSearch] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+  const { theme, setTheme } = useTheme();
 
   const openEdit = (idx: number) => {
     setEditingIndex(idx);
@@ -72,36 +81,74 @@ function App() {
 
   const cancelEdit = () => setDrawerOpen(false);
 
+  const exportCsv = () => {
+    alert('Export as CSV');
+  };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === '/' && document.activeElement !== searchRef.current) {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+      if (e.key === 'a') {
+        e.preventDefault();
+        addTicker();
+      }
+      if (e.key === 'e') {
+        e.preventDefault();
+        exportCsv();
+      }
+      if (e.key === 't') {
+        e.preventDefault();
+        setTheme(theme === 'light' ? 'dark' : 'light');
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [theme, setTheme, addTicker, exportCsv]);
+
   const filtered = tickers.filter((t) => {
     const term = search.toLowerCase();
     const matchesSearch =
       t.symbol.toLowerCase().includes(term) || t.name.toLowerCase().includes(term);
-    const matchesDate = filterDate ? t.priceAsOf === filterDate : true;
+    const matchesDate = filterDate ? t.priceAsOf === format(filterDate, 'yyyy-MM-dd') : true;
     return matchesSearch && matchesDate;
   });
 
   return (
-    <div className="app-container">
-      <div className="top-bar">
-        <h1>Stock Watchlist</h1>
-        <div className="controls">
-          <button onClick={addTicker}>Add Ticker</button>
-          <button onClick={() => alert('Export as CSV')}>Export CSV</button>
-          <input
-            type="date"
-            value={filterDate}
-            onChange={(e) => setFilterDate(e.target.value)}
-            aria-label="Price As-Of"
-          />
-          <input
-            type="text"
-            placeholder="Search"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-          <ModeToggle />
-        </div>
-      </div>
+    <AppShell
+      toolbar={
+        <>
+          <h1 className="text-xl font-semibold">Stock Watchlist</h1>
+          <div className="flex items-center gap-2">
+            <Button onClick={addTicker}>Add Ticker</Button>
+            <Button variant="outline" onClick={exportCsv}>
+              Export CSV
+            </Button>
+            <Popover>
+              <PopoverTrigger>
+                <Button variant="outline" className="w-[150px] justify-start text-left font-normal">
+                  {filterDate ? format(filterDate, 'yyyy-MM-dd') : 'Price As-Of'}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="p-0">
+                <Calendar selected={filterDate} onSelect={setFilterDate} />
+              </PopoverContent>
+            </Popover>
+            <Input
+              ref={searchRef}
+              type="text"
+              placeholder="Search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-[150px]"
+            />
+            <ModeToggle />
+          </div>
+        </>
+      }
+    >
       {filtered.length === 0 ? (
         <p className="empty-state">No tickers yet. Click Add Ticker to begin.</p>
       ) : (
@@ -135,7 +182,7 @@ function App() {
           onCancel={cancelEdit}
         />
       )}
-    </div>
+    </AppShell>
   );
 }
 

--- a/my-app/src/components/AppShell.tsx
+++ b/my-app/src/components/AppShell.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+
+interface AppShellProps {
+  toolbar: ReactNode;
+  children: ReactNode;
+}
+
+export default function AppShell({ toolbar, children }: AppShellProps) {
+  return (
+    <div className="app-container">
+      <div className="sticky top-0 z-20 border-b bg-background p-4 flex items-center justify-between">{toolbar}</div>
+      <main className="flex-1 overflow-auto">{children}</main>
+    </div>
+  );
+}

--- a/my-app/src/components/ui/calendar.tsx
+++ b/my-app/src/components/ui/calendar.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { format } from "date-fns";
+
+interface CalendarProps {
+  selected?: Date;
+  onSelect: (date: Date | undefined) => void;
+}
+
+function Calendar({ selected, onSelect }: CalendarProps) {
+  return (
+    <input
+      type="date"
+      value={selected ? format(selected, "yyyy-MM-dd") : ""}
+      onChange={(e) =>
+        onSelect(e.target.value ? new Date(e.target.value) : undefined)
+      }
+      className="rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    />
+  );
+}
+
+export { Calendar };

--- a/my-app/src/components/ui/input.tsx
+++ b/my-app/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = "text", ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/my-app/src/components/ui/popover.tsx
+++ b/my-app/src/components/ui/popover.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface PopoverContextProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const PopoverContext = React.createContext<PopoverContextProps | null>(null);
+
+function Popover({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <PopoverContext.Provider value={{ open, setOpen }}>
+      <div className="relative inline-block">{children}</div>
+    </PopoverContext.Provider>
+  );
+}
+
+function PopoverTrigger({ children }: { children: React.ReactElement }) {
+  const ctx = React.useContext(PopoverContext);
+  if (!ctx) return null;
+  return React.cloneElement(children, {
+    onClick: () => ctx.setOpen(!ctx.open),
+  });
+}
+
+function PopoverContent({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const ctx = React.useContext(PopoverContext);
+  if (!ctx || !ctx.open) return null;
+  return (
+    <div
+      className={cn(
+        "absolute z-50 mt-2 rounded-md border bg-popover p-2 text-popover-foreground shadow-md",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export { Popover, PopoverTrigger, PopoverContent };


### PR DESCRIPTION
## Summary
- build AppShell layout with sticky toolbar and main content
- add toolbar actions with shadcn components and keyboard shortcuts
- provide custom popover, calendar and input components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7c3fa9088332a9926d13db9726c8