### PR TITLE
feat: add KPI cards with metrics

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -36,6 +36,46 @@
   border-radius: 4px;
 }
 
+.kpi-container {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+}
+
+.kpi-card {
+  flex: 1;
+  padding: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: hsl(var(--card));
+}
+
+.kpi-card .label {
+  font-size: 0.875rem;
+  color: var(--color-secondary-text);
+}
+
+.kpi-card .value {
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+
+.kpi-card.skeleton {
+  height: 60px;
+  background: hsl(var(--muted));
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.kpi-error {
+  padding: 16px;
+  color: var(--color-danger);
+}
+
 .table-wrapper {
   overflow: auto;
   flex: 1;

--- a/my-app/src/components/KpiCards.tsx
+++ b/my-app/src/components/KpiCards.tsx
@@ -1,0 +1,63 @@
+import type { Ticker } from '../types';
+import { differenceInDays } from 'date-fns';
+
+interface KpiCardsProps {
+  tickers: Ticker[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export default function KpiCards({ tickers, isLoading, isError }: KpiCardsProps) {
+  if (isLoading) {
+    return (
+      <div className="kpi-container">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="kpi-card skeleton" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <div className="kpi-error">Failed to load KPIs.</div>;
+  }
+
+  const total = tickers.length;
+
+  const { totalUpside, count } = tickers.reduce(
+    (acc, t) => {
+      if (t.fairValue !== undefined && t.priceClose !== undefined) {
+        acc.totalUpside += ((t.fairValue - t.priceClose) / t.priceClose) * 100;
+        acc.count += 1;
+      }
+      return acc;
+    },
+    { totalUpside: 0, count: 0 }
+  );
+
+  const avgUpside = count > 0 ? totalUpside / count : 0;
+
+  const soonCount = tickers.filter((t) => {
+    if (!t.earningsDate) return false;
+    const days = differenceInDays(new Date(t.earningsDate), new Date());
+    return days >= 0 && days <= 21;
+  }).length;
+
+  return (
+    <div className="kpi-container">
+      <div className="kpi-card">
+        <span className="label">Total Tickers</span>
+        <span className="value">{total}</span>
+      </div>
+      <div className="kpi-card">
+        <span className="label">Avg Upside %</span>
+        <span className="value">{avgUpside.toFixed(1)}%</span>
+      </div>
+      <div className="kpi-card">
+        <span className="label">Next Earnings Soon</span>
+        <span className="value">{soonCount}</span>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `KpiCards` component for Total Tickers, Avg Upside %, and upcoming earnings
- show loading skeletons and error state for KPI section
- style KPI cards and integrate into app

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7c4bac1083329eb98b27ae4355af