### PR TITLE
Remove unsupported asChild prop from PopoverTrigger

### DIFF
--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -147,7 +147,7 @@ function App() {
               Export CSV
             </Button>
             <Popover>
-              <PopoverTrigger asChild>
+              <PopoverTrigger>
                 <Button variant="outline" className="w-[150px] justify-start text-left font-normal">
                   {filterDate ? format(filterDate, 'yyyy-MM-dd') : 'Price As-Of'}
                 </Button>


### PR DESCRIPTION
## Summary
- remove `asChild` prop when using custom `PopoverTrigger` so TypeScript accepts component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a86656f1483329baacb12e4dc1bde