### PR TITLE
Add openpyxl dependency and SEC screener tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 pandas
+openpyxl

--- a/tests/test_sec_screener.py
+++ b/tests/test_sec_screener.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import sec_screener as ss
+
+
+def test_detect_quarter():
+    assert ss.detect_quarter("2024-01-15") == "Q1"
+    assert ss.detect_quarter("2024-04-02") == "Q2"
+    assert ss.detect_quarter("2024-07-19") == "Q3"
+
+
+def test_build_10q_url():
+    url = ss.build_10q_url("0000123456", "0001234567-24-000045", "doc.txt")
+    assert url == "https://www.sec.gov/Archives/edgar/data/123456/000123456724000045/doc.txt"
+
+
+def test_session_has_user_agent():
+    assert ss.session.headers["User-Agent"] == "Jerry Mcguire"


### PR DESCRIPTION
## Summary
- add openpyxl to requirements for Excel output
- add tests for SEC screener utility functions and user-agent header

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689be41187c483329d4278f77dd1bc88