### PR TITLE
Add download error tests

### DIFF
--- a/tests/test_sec_screener.py
+++ b/tests/test_sec_screener.py
@@ -19,3 +19,62 @@ def test_build_10q_url():
 
 def test_session_has_user_agent():
     assert ss.session.headers["User-Agent"] == "Jerry Mcguire"
+
+
+import pytest
+import requests
+import pandas as pd
+
+
+def test_download_file_error(monkeypatch, tmp_path):
+    """download_file should propagate request errors."""
+
+    def fake_make_request(url):  # noqa: ARG001
+        raise requests.HTTPError("bad url")
+
+    monkeypatch.setattr(ss, "make_request", fake_make_request)
+    with pytest.raises(requests.HTTPError):
+        ss.download_file("http://example.com/file.txt", tmp_path / "file.txt")
+
+
+def test_main_handles_download_error(monkeypatch):
+    """main() records ERROR status when download fails."""
+
+    monkeypatch.setattr(
+        ss,
+        "WATCHLIST",
+        [{"name": "Test", "ticker": "TEST"}],
+    )
+
+    def fake_load_ticker_map(cache_dir):  # noqa: ARG001
+        return pd.DataFrame([
+            {"ticker": "TEST", "cik_str": "0000000000"}
+        ])
+
+    def fake_get_latest_10q(cik):  # noqa: ARG001
+        return {
+            "filingDate": "2024-05-01",
+            "reportDate": "2024-03-31",
+            "accessionNumber": "0000000000-24-000001",
+            "primaryDocument": "test.htm",
+            "amended": False,
+        }
+
+    def fake_download_file(url, out_path):  # noqa: ARG001
+        raise requests.HTTPError("download failed")
+
+    captured = {}
+
+    def fake_write_excel(rows, path):  # noqa: ARG001
+        captured["rows"] = rows
+
+    monkeypatch.setattr(ss, "load_ticker_map", fake_load_ticker_map)
+    monkeypatch.setattr(ss, "get_latest_10q", fake_get_latest_10q)
+    monkeypatch.setattr(ss, "download_file", fake_download_file)
+    monkeypatch.setattr(ss, "write_excel", fake_write_excel)
+
+    ss.main()
+
+    rows = captured["rows"]
+    assert rows[0]["Status"] == "ERROR"
+    assert "download failed" in rows[0]["Notes"]


### PR DESCRIPTION
## Summary
- add unit test verifying download_file propagates request errors
- add integration-style test ensuring main logs ERROR status when file download fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689be650d5048332aceb739672672146