### PR TITLE
Ensure headers used for all SEC requests

### DIFF
--- a/tests/test_sec_screener.py
+++ b/tests/test_sec_screener.py
@@ -29,7 +29,7 @@ import pandas as pd
 def test_download_file_error(monkeypatch, tmp_path):
     """download_file should propagate request errors."""
 
-    def fake_make_request(url):  # noqa: ARG001
+    def fake_make_request(url, *, headers=None):  # noqa: ARG001, ARG002
         raise requests.HTTPError("bad url")
 
     monkeypatch.setattr(ss, "make_request", fake_make_request)


### PR DESCRIPTION
## Summary
- Pass a custom headers dict to all HTTP requests to satisfy SEC's user-agent requirements.
- Adjust tests to handle the updated `make_request` signature.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689be9c7e3408332ad358f6933105a4c